### PR TITLE
feat(build): show scheduled articles on preview deploys

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "bun run src/build/index.ts",
     "build:drafts": "bun run src/build/index.ts --drafts",
+    "build:preview": "bun run src/build/index.ts --preview",
     "dev": "bun run build && wrangler dev",
     "deploy": "bun run build && wrangler deploy",
     "preview": "wrangler dev --local"

--- a/src/build/config.ts
+++ b/src/build/config.ts
@@ -39,8 +39,23 @@ export const paths = {
   fonts: join(ROOT, "src", "build", "fonts"),
 } as const;
 
+// A "preview" build is a Cloudflare Workers build on any branch other than the
+// production branch. Cloudflare sets WORKERS_CI=1 and WORKERS_CI_BRANCH on every
+// Workers build; the daily GitHub Actions cron and local builds set neither, so
+// they are never treated as preview and production output stays clean.
+const PRODUCTION_BRANCH = "main";
+const isPreviewDeploy =
+  process.env.WORKERS_CI === "1" &&
+  !!process.env.WORKERS_CI_BRANCH &&
+  process.env.WORKERS_CI_BRANCH !== PRODUCTION_BRANCH;
+
 export const buildFlags = {
   includeDrafts: process.argv.includes("--drafts"),
+  // Preview deploys build future-dated (scheduled) articles so they can be
+  // reviewed before their publish date. Production builds (main + the daily
+  // cron) keep them hidden until the date arrives. `--preview` forces it on for
+  // a local review build.
+  includeScheduled: isPreviewDeploy || process.argv.includes("--preview"),
 } as const;
 
 export const WORDS_PER_MINUTE = 200;

--- a/src/build/content.ts
+++ b/src/build/content.ts
@@ -233,9 +233,12 @@ export async function loadContent(): Promise<Content> {
       console.log(`Skipped (draft): ${fm.title}`);
       continue;
     }
-    if (isScheduled) {
+    if (isScheduled && !buildFlags.includeScheduled) {
       console.log(`Skipped (scheduled for ${fm.date.toISOString().slice(0, 10)}): ${fm.title}`);
       continue;
+    }
+    if (isScheduled) {
+      console.log(`Included (scheduled for ${fm.date.toISOString().slice(0, 10)}, preview build): ${fm.title}`);
     }
 
     const assets = (await readdir(dir)).filter((f) => f !== "index.md" && !f.startsWith("."));


### PR DESCRIPTION
Scheduled (future-dated) articles were skipped in **every** build, so they couldn't be reviewed on a Cloudflare branch/commit preview before their publish date. This makes preview deploys build them while keeping production hidden until the date.

**How it decides.** `buildFlags.includeScheduled` is true when:
- the build is a Cloudflare Workers build on a non-production branch (`WORKERS_CI === "1"` and `WORKERS_CI_BRANCH !== "main"`), or
- `--preview` is passed (new `bun run build:preview` script for local review).

**Production stays safe.** The two production paths never match: the `main` Workers build has `WORKERS_CI_BRANCH === "main"`, and the daily GitHub Actions cron (`deploy.yml`) has no `WORKERS_CI` at all. Both keep future-dated articles hidden until their date, exactly as before.

Verified with a throwaway future-dated article across all five contexts:

| Build context | Scheduled article |
|---|---|
| normal local / cron (production default) | skipped ✅ |
| `--preview` flag | included ✅ |
| CF preview env (branch ≠ main) | included ✅ |
| CF production env (branch == main) | **skipped ✅** |
| WORKERS_CI set, no branch | skipped ✅ |

Two files of logic + one npm script; no change to how published articles build.