### PR TITLE
ci(lighthouse): raise the script budget to fit the analytics beacon

### DIFF
--- a/.github/lighthouse/budget.json
+++ b/.github/lighthouse/budget.json
@@ -4,7 +4,7 @@
     "resourceSizes": [
       { "resourceType": "document", "budget": 40 },
       { "resourceType": "stylesheet", "budget": 20 },
-      { "resourceType": "script", "budget": 15 },
+      { "resourceType": "script", "budget": 20 },
       { "resourceType": "font", "budget": 280 },
       { "resourceType": "total", "budget": 400 }
     ]


### PR DESCRIPTION
The nightly `Deploy` workflow's **Verify Production** job has failed since the go-1-1 merge. `Deploy Worker` succeeds (publishing is unaffected), but the production Lighthouse gate is red.

## Cause

Allowing `static.cloudflareinsights.com` in the CSP let Cloudflare's Web Analytics beacon load. It is **11,577 bytes** against a **15,360-byte** script budget.

`/articles/` is the only page carrying both `main.js` and `search.js`:

| Script | Bytes |
| --- | --- |
| `assets/main.js` | 2,217 |
| `assets/search.js` | 2,022 |
| `static.cloudflareinsights.com/beacon.min.js` | 11,577 |
| **Total** | **15,816** (budget 15,360) |

Over by 456 bytes. The gate was measuring Cloudflare's code more than ours.

This does not show up on PR checks because the beacon is only injected on the production domain.

## Fix

Raise the script budget to 20KB. First-party scripts are **4,239 bytes** on the heaviest page, so this covers the beacon and still leaves roughly the same again of headroom before the gate trips, keeping it meaningful for our own code.