### PR TITLE
feat(ai-roadmap): the /ai/ page — de-personalised, verified, no links, footer-only

### DIFF
--- a/content/data/ai-roadmap.yml
+++ b/content/data/ai-roadmap.yml
@@ -1,0 +1,800 @@
+# The AI knowledge tree: every branch of AI except computer vision, as
+# structured courses only. Generated once from the source map, then hand-edited.
+#
+# status: todo | doing | done   (public, shown on the page)
+# rating: 1-5                   (optional, only meaningful once status is done)
+# verdict: markdown            (optional, a couple of sentences)
+---
+title: The AI knowledge tree
+lede: >-
+  Every branch of AI except computer vision, as structured courses only: no
+  articles, no blog posts, no "read this repo". Ten tiers ordered by dependency,
+  each one stating what it builds on. Within a tier the domains are siblings and
+  can be taken in any order.
+note: >-
+  Every entry names the course, the institution and its course code, so it
+  resolves to exactly one thing. Nothing here is pruned to a shortest path: the
+  tree covers each branch as it exists. Computer vision is deliberately out of
+  scope, though the multimodal material in tier 5 necessarily touches it.
+tiers:
+  - id: mathematical-foundations
+    n: 0
+    name: "Mathematical foundations"
+    short: "Mathematics"
+    tagline: "Everything downstream assumes this material. Probability and statistics carry the most weight later."
+    builds_on: []
+    domains:
+      - name: "Linear algebra"
+        courses:
+          - slug: mit-18-06
+            title: "Linear Algebra (18.06)"
+            org: "MIT OCW"
+            code: "18.06"
+            tags: [free, univ]
+            status: todo
+          - slug: mit-18-065
+            title: "Matrix Methods in Data Analysis, Signal Processing & ML (18.065)"
+            org: "MIT OCW"
+            code: "18.065"
+            tags: [free, univ]
+            status: todo
+          - slug: imperial-mathematics-for-machine-learning-l
+            title: "Mathematics for Machine Learning: Linear Algebra"
+            org: "Imperial College London"
+            tags: [coursera, paid]
+            status: todo
+          - slug: 3b1b-essence-of-linear-algebra
+            title: "Essence of Linear Algebra"
+            org: "3Blue1Brown"
+            tags: [free, series]
+            status: todo
+      - name: "Calculus & matrix calculus"
+        courses:
+          - slug: imperial-mathematics-for-machine-learning-m
+            title: "Mathematics for Machine Learning: Multivariate Calculus"
+            org: "Imperial College London"
+            tags: [coursera, paid]
+            status: todo
+          - slug: mit-18-02
+            title: "Multivariable Calculus (18.02)"
+            org: "MIT OCW"
+            code: "18.02"
+            tags: [free, univ]
+            status: todo
+          - slug: mit-18-s096
+            title: "Matrix Calculus for Machine Learning and Beyond (18.S096)"
+            org: "MIT OCW"
+            code: "18.S096"
+            tags: [free, univ]
+            status: todo
+      - name: "Probability & statistics"
+        courses:
+          - slug: mitx-6-431x
+            title: "Probability - The Science of Uncertainty and Data (6.431x)"
+            org: "MITx / edX"
+            code: "6.431x"
+            tags: [free, paid, univ]
+            status: todo
+          - slug: harvard-stat-110
+            title: "Statistics 110: Probability"
+            org: "Harvard"
+            code: "Stat 110"
+            tags: [free, univ]
+            status: todo
+          - slug: mitx-micromasters-in-statistics-and-dat
+            title: "MicroMasters in Statistics and Data Science"
+            org: "MITx / edX"
+            tags: [paid, cert]
+            status: todo
+          - slug: ucsc-bayesian-statistics-from-concept-t
+            title: "Bayesian Statistics: From Concept to Data Analysis"
+            org: "UC Santa Cruz"
+            tags: [coursera, paid]
+            status: todo
+      - name: "Information theory"
+        courses:
+          - slug: cambridge-information-theory-pattern-recogni
+            title: "Information Theory, Pattern Recognition and Neural Networks"
+            org: "Cambridge (MacKay)"
+            tags: [free, series]
+            status: todo
+          - slug: stanford-ee276
+            title: "Information Theory (EE276)"
+            org: "Stanford"
+            code: "EE276"
+            tags: [free, univ]
+            status: todo
+      - name: "Optimization"
+        courses:
+          - slug: stanford-ee364a
+            title: "Convex Optimization I (EE364A)"
+            org: "Stanford Online"
+            code: "EE364A"
+            tags: [free, univ]
+            status: todo
+          - slug: stanford-ee364b
+            title: "Convex Optimization II (EE364B)"
+            org: "Stanford Online"
+            code: "EE364B"
+            tags: [free, univ]
+            status: todo
+          - slug: melbourne-discrete-optimization
+            title: "Discrete Optimization"
+            org: "University of Melbourne"
+            tags: [coursera, paid]
+            status: todo
+          - slug: mit-18-335
+            title: "Introduction to Numerical Methods (18.335)"
+            org: "MIT OCW"
+            code: "18.335"
+            tags: [free, univ]
+            status: todo
+  - id: classical-machine-learning
+    n: 1
+    name: "Classical machine learning"
+    short: "Classical ML"
+    tagline: "The pre-deep-learning core: estimators, generalisation, and the theory the rest leans on."
+    builds_on: [mathematical-foundations]
+    domains:
+      - name: "Applied / intro ML"
+        courses:
+          - slug: stanford-machine-learning-specialization-3-
+            title: "Machine Learning Specialization (3 courses)"
+            org: "DeepLearning.AI + Stanford (Ng)"
+            tags: [coursera, paid]
+            status: todo
+          - slug: stanford-cs229
+            title: "Machine Learning (CS229)"
+            org: "Stanford"
+            code: "CS229"
+            tags: [free, univ]
+            status: todo
+          - slug: caltech-learning-from-data
+            title: "Learning From Data"
+            org: "Caltech (Abu-Mostafa)"
+            tags: [free, univ]
+            status: todo
+          - slug: cmu-10-601
+            title: "Introduction to Machine Learning (10-601 / 10-701)"
+            org: "CMU"
+            code: "10-601"
+            tags: [free, univ]
+            status: todo
+      - name: "Statistical learning"
+        courses:
+          - slug: stanford-statistical-learning-with-python
+            title: "Statistical Learning with Python"
+            org: "Stanford Online / edX (Hastie & Tibshirani)"
+            tags: [free, univ]
+            status: todo
+          - slug: mit-9-520
+            title: "Statistical Learning Theory and Applications (9.520)"
+            org: "MIT"
+            code: "9.520"
+            tags: [free, univ]
+            status: todo
+          - slug: stanford-cs229t
+            title: "Statistical Learning Theory (CS229T)"
+            org: "Stanford"
+            code: "CS229T"
+            tags: [free, univ]
+            status: todo
+      - name: "Bayesian & probabilistic methods"
+        courses:
+          - slug: tubingen-probabilistic-machine-learning
+            title: "Probabilistic Machine Learning"
+            org: "University of Tübingen (Hennig)"
+            tags: [free, series]
+            status: todo
+          - slug: tubingen-numerics-of-machine-learning
+            title: "Numerics of Machine Learning"
+            org: "University of Tübingen (Hennig)"
+            tags: [free, series]
+            status: todo
+          - slug: mpi-statistical-rethinking
+            title: "Statistical Rethinking"
+            org: "Max Planck (McElreath)"
+            tags: [free, series]
+            status: todo
+          - slug: hse-bayesian-methods-for-machine-learn
+            title: "Bayesian Methods for Machine Learning"
+            org: "HSE University"
+            tags: [coursera, paid]
+            status: todo
+      - name: "Probabilistic graphical models"
+        courses:
+          - slug: stanford-probabilistic-graphical-models-spe
+            title: "Probabilistic Graphical Models Specialization (3 courses)"
+            org: "Stanford (Koller)"
+            tags: [coursera, paid]
+            status: todo
+          - slug: stanford-cs228
+            title: "Probabilistic Graphical Models (CS228)"
+            org: "Stanford"
+            code: "CS228"
+            tags: [free, univ]
+            status: todo
+          - slug: cmu-10-708
+            title: "Probabilistic Graphical Models (10-708)"
+            org: "CMU"
+            code: "10-708"
+            tags: [free, univ]
+            status: todo
+      - name: "Causal inference"
+        courses:
+          - slug: columbia-causal-inference-i-ii
+            title: "Causal Inference I & II"
+            org: "Columbia University"
+            tags: [coursera, paid]
+            status: todo
+          - slug: brady-neal-introduction-to-causal-inference
+            title: "Introduction to Causal Inference"
+            org: "Brady Neal"
+            tags: [free, series]
+            status: todo
+  - id: deep-learning-core
+    n: 2
+    name: "Deep learning core"
+    short: "Deep learning"
+    tagline: "Backprop, optimisation, architectures, generative models."
+    builds_on: [classical-machine-learning]
+    domains:
+      - name: "Deep learning fundamentals"
+        courses:
+          - slug: dlai-deep-learning-specialization-5-cou
+            title: "Deep Learning Specialization (5 courses)"
+            org: "DeepLearning.AI (Ng)"
+            tags: [coursera, paid]
+            status: todo
+          - slug: mit-6-s191
+            title: "Introduction to Deep Learning (6.S191)"
+            org: "MIT"
+            code: "6.S191"
+            tags: [free, univ]
+            status: todo
+          - slug: stanford-cs230
+            title: "Deep Learning (CS230)"
+            org: "Stanford"
+            code: "CS230"
+            tags: [free, univ]
+            status: todo
+          - slug: cmu-11-785
+            title: "Introduction to Deep Learning (11-785)"
+            org: "CMU"
+            code: "11-785"
+            tags: [free, univ]
+            status: todo
+          - slug: nyu-deep-learning
+            title: "Deep Learning"
+            org: "NYU (LeCun & Canziani)"
+            tags: [free, univ]
+            status: todo
+          - slug: berkeley-cs182
+            title: "Deep Learning (CS182)"
+            org: "UC Berkeley"
+            code: "CS182"
+            tags: [free, univ]
+            status: todo
+          - slug: fastai-practical-deep-learning-for-coders
+            title: "Practical Deep Learning for Coders"
+            org: "fast.ai"
+            tags: [free, series]
+            status: todo
+      - name: "Generative models"
+        courses:
+          - slug: berkeley-cs294-158
+            title: "Deep Unsupervised Learning (CS294-158)"
+            org: "UC Berkeley"
+            code: "CS294-158"
+            tags: [free, univ]
+            status: todo
+          - slug: stanford-cs236
+            title: "Deep Generative Models (CS236)"
+            org: "Stanford"
+            code: "CS236"
+            tags: [free, univ]
+            status: todo
+          - slug: hf-diffusion-course
+            title: "Diffusion Course"
+            org: "Hugging Face"
+            tags: [free, cert]
+            status: todo
+      - name: "Graph & geometric learning"
+        courses:
+          - slug: stanford-cs224w
+            title: "Machine Learning with Graphs (CS224W)"
+            org: "Stanford"
+            code: "CS224W"
+            tags: [free, univ]
+            status: todo
+          - slug: ammi-geometric-deep-learning
+            title: "Geometric Deep Learning"
+            org: "AMMI (Bronstein et al.)"
+            tags: [free, series]
+            status: todo
+  - id: nlp-transformers-llms
+    n: 3
+    name: "NLP, transformers & LLMs"
+    short: "NLP & LLMs"
+    tagline: "From word vectors to building a language model end to end. CS336 is the densest item in the tree."
+    builds_on: [deep-learning-core]
+    domains:
+      - name: "NLP foundations"
+        courses:
+          - slug: stanford-cs224n
+            title: "NLP with Deep Learning (CS224N)"
+            org: "Stanford"
+            code: "CS224N"
+            tags: [free, univ]
+            status: todo
+          - slug: cmu-11-711
+            title: "Advanced NLP (11-711)"
+            org: "CMU"
+            code: "11-711"
+            tags: [free, univ]
+            status: todo
+          - slug: dlai-natural-language-processing-specia
+            title: "Natural Language Processing Specialization (4 courses)"
+            org: "DeepLearning.AI"
+            tags: [coursera, paid]
+            status: todo
+          - slug: hf-llm-course-formerly-nlp-course
+            title: "LLM Course (formerly NLP Course)"
+            org: "Hugging Face"
+            tags: [free, cert]
+            status: todo
+      - name: "Transformers & building LLMs"
+        courses:
+          - slug: stanford-cs336
+            title: "Language Modeling from Scratch (CS336)"
+            org: "Stanford"
+            code: "CS336"
+            tags: [free, univ]
+            status: todo
+          - slug: stanford-cs25
+            title: "Transformers United (CS25)"
+            org: "Stanford"
+            code: "CS25"
+            tags: [free, series]
+            status: todo
+          - slug: karpathy-neural-networks-zero-to-hero
+            title: "Neural Networks: Zero to Hero"
+            org: "Karpathy"
+            tags: [free, series]
+            status: todo
+          - slug: dlai-generative-ai-with-large-language-
+            title: "Generative AI with Large Language Models"
+            org: "DeepLearning.AI + AWS"
+            tags: [coursera, paid]
+            status: todo
+          - slug: ibm-generative-ai-engineering-with-llm
+            title: "Generative AI Engineering with LLMs Specialization"
+            org: "IBM"
+            tags: [coursera, paid]
+            status: todo
+      - name: "Fine-tuning & post-training"
+        courses:
+          - slug: dlai-finetuning-large-language-models
+            title: "Finetuning Large Language Models"
+            org: "DeepLearning.AI"
+            tags: [free, series]
+            status: todo
+          - slug: dlai-reinforcement-learning-from-human-
+            title: "Reinforcement Learning from Human Feedback"
+            org: "DeepLearning.AI"
+            tags: [free, series]
+            status: todo
+          - slug: stanford-cs336-2
+            title: "Post-training & alignment (within CS336)"
+            org: "Stanford"
+            code: "CS336"
+            tags: [free, univ]
+            status: todo
+      - name: "Prompting, RAG & context"
+        courses:
+          - slug: dlai-chatgpt-prompt-engineering-for-dev
+            title: "ChatGPT Prompt Engineering for Developers"
+            org: "DeepLearning.AI"
+            tags: [free, series]
+            status: todo
+          - slug: vanderbilt-uni-prompt-engineering-specialization
+            title: "Prompt Engineering Specialization"
+            org: "Vanderbilt University"
+            tags: [coursera, paid]
+            status: todo
+          - slug: dlai-building-and-evaluating-advanced-r
+            title: "Building and Evaluating Advanced RAG"
+            org: "DeepLearning.AI"
+            tags: [free, series]
+            status: todo
+          - slug: uiuc-text-retrieval-and-search-engines
+            title: "Text Retrieval and Search Engines"
+            org: "UIUC"
+            tags: [coursera, paid]
+            status: todo
+      - name: "Agents & tool use"
+        courses:
+          - slug: hf-ai-agents-course
+            title: "AI Agents Course"
+            org: "Hugging Face"
+            tags: [free, cert]
+            status: todo
+          - slug: hf-mcp-course
+            title: "MCP Course"
+            org: "Hugging Face"
+            tags: [free, cert]
+            status: todo
+          - slug: berkeley-cs294
+            title: "Large Language Model Agents MOOC"
+            org: "UC Berkeley (Dawn Song)"
+            code: "CS294"
+            tags: [free, univ]
+            status: todo
+      - name: "Evaluation & interpretability"
+        courses:
+          - slug: dlai-evaluating-and-debugging-generativ
+            title: "Evaluating and Debugging Generative AI"
+            org: "DeepLearning.AI"
+            tags: [free, series]
+            status: todo
+          - slug: dlai-automated-testing-for-llmops
+            title: "Automated Testing for LLMOps"
+            org: "DeepLearning.AI"
+            tags: [free, series]
+            status: todo
+          - slug: arena-arena-alignment-research-engineer-
+            title: "ARENA - Alignment Research Engineer Accelerator curriculum"
+            org: "ARENA"
+            tags: [free, series]
+            status: todo
+  - id: reinforcement-learning
+    n: 4
+    name: "Reinforcement learning"
+    short: "RL"
+    tagline: "A standalone branch. Feeds post-training (RLHF, GRPO) back into tier 3."
+    builds_on: [deep-learning-core]
+    domains:
+      - name: "Classical RL"
+        courses:
+          - slug: university-of--reinforcement-learning-specializat
+            title: "Reinforcement Learning Specialization (4 courses)"
+            org: "University of Alberta"
+            tags: [coursera, paid]
+            status: todo
+          - slug: deepmind-reinforcement-learning-course
+            title: "Reinforcement Learning Course"
+            org: "DeepMind × UCL (Silver)"
+            tags: [free, series]
+            status: todo
+      - name: "Deep RL"
+        courses:
+          - slug: berkeley-cs285
+            title: "Deep Reinforcement Learning (CS285)"
+            org: "UC Berkeley"
+            code: "CS285"
+            tags: [free, univ]
+            status: todo
+          - slug: hf-deep-rl-course
+            title: "Deep RL Course"
+            org: "Hugging Face"
+            tags: [free, cert]
+            status: todo
+          - slug: openai-spinning-up-in-deep-rl
+            title: "Spinning Up in Deep RL"
+            org: "OpenAI"
+            tags: [free, series]
+            status: todo
+          - slug: stanford-cs234
+            title: "Reinforcement Learning (CS234)"
+            org: "Stanford"
+            code: "CS234"
+            tags: [free, univ]
+            status: todo
+  - id: other-modalities-applicati
+    n: 5
+    name: "Other modalities & applications"
+    short: "Modalities"
+    tagline: "Speech, tabular data, time series, and multimodal systems. Multimodal work necessarily touches vision."
+    builds_on: [deep-learning-core]
+    domains:
+      - name: "Speech & audio"
+        courses:
+          - slug: hf-audio-course
+            title: "Audio Course"
+            org: "Hugging Face"
+            tags: [free, cert]
+            status: todo
+          - slug: stanford-cs224s
+            title: "Spoken Language Processing (CS224S)"
+            org: "Stanford"
+            code: "CS224S"
+            tags: [free, univ]
+            status: todo
+      - name: "Time series & forecasting"
+        courses:
+          - slug: suny-practical-time-series-analysis
+            title: "Practical Time Series Analysis"
+            org: "SUNY"
+            tags: [coursera, paid]
+            status: todo
+          - slug: dlai-sequences-time-series-and-predicti
+            title: "Sequences, Time Series and Prediction"
+            org: "DeepLearning.AI"
+            tags: [coursera, paid]
+            status: todo
+      - name: "Recommenders & information retrieval"
+        courses:
+          - slug: university-of--recommender-systems-specialization
+            title: "Recommender Systems Specialization (5 courses)"
+            org: "University of Minnesota"
+            tags: [coursera, paid]
+            status: todo
+          - slug: stanford-cs276
+            title: "Information Retrieval and Web Search (CS276)"
+            org: "Stanford"
+            code: "CS276"
+            tags: [free, univ]
+            status: todo
+          - slug: stanford-cs246
+            title: "Mining Massive Datasets (CS246)"
+            org: "Stanford"
+            code: "CS246"
+            tags: [free, univ]
+            status: todo
+      - name: "Embodied & robotics"
+        courses:
+          - slug: hf-robotics-course-lerobot
+            title: "Robotics Course (LeRobot)"
+            org: "Hugging Face"
+            tags: [free, cert]
+            status: todo
+          - slug: hf-ml-for-games-course
+            title: "ML for Games Course"
+            org: "Hugging Face"
+            tags: [free, cert]
+            status: todo
+  - id: ml-systems-efficiency
+    n: 6
+    name: "ML systems & efficiency"
+    short: "Systems"
+    tagline: "Kernels, quantisation, distributed training, and serving. Where systems engineering meets models."
+    builds_on: [deep-learning-core]
+    domains:
+      - name: "Parallel & GPU programming"
+        courses:
+          - slug: cmu-15-418
+            title: "Parallel Computer Architecture and Programming (15-418/618)"
+            org: "CMU"
+            code: "15-418"
+            tags: [free, univ]
+            status: todo
+          - slug: stanford-cs149
+            title: "Parallel Computing (CS149)"
+            org: "Stanford"
+            code: "CS149"
+            tags: [free, univ]
+            status: todo
+          - slug: nvidia-dli-fundamentals-of-accelerated-comput
+            title: "Fundamentals of Accelerated Computing with CUDA C/C++"
+            org: "NVIDIA DLI"
+            tags: [paid, cert]
+            status: todo
+          - slug: uiuc-community-programming-massively-parallel-pro
+            title: "Programming Massively Parallel Processors (PMPP) lecture series"
+            org: "UIUC / community"
+            tags: [free, series]
+            status: todo
+          - slug: gpu-mode-gpu-mode-lecture-series
+            title: "GPU MODE lecture series"
+            org: "GPU MODE"
+            tags: [free, series]
+            status: todo
+      - name: "Deep learning systems & compilers"
+        courses:
+          - slug: cmu-10-414
+            title: "Deep Learning Systems: Algorithms and Implementation (10-414/714)"
+            org: "CMU (Chen & Dettmers)"
+            code: "10-414"
+            tags: [free, univ]
+            status: todo
+          - slug: mlc-ai-tianqi--machine-learning-compilation
+            title: "Machine Learning Compilation"
+            org: "MLC.ai (Tianqi Chen)"
+            tags: [free, series]
+            status: todo
+      - name: "Efficient inference & TinyML"
+        courses:
+          - slug: mit-6-5940
+            title: "TinyML and Efficient Deep Learning Computing (6.5940)"
+            org: "MIT (Song Han)"
+            code: "6.5940"
+            tags: [free, univ]
+            status: todo
+          - slug: mit-6-5930
+            title: "Hardware Architecture for Deep Learning (6.5930)"
+            org: "MIT"
+            code: "6.5930"
+            tags: [free, univ]
+            status: todo
+      - name: "ML systems design"
+        courses:
+          - slug: stanford-cs329s
+            title: "Machine Learning Systems Design (CS329S)"
+            org: "Stanford"
+            code: "CS329S"
+            tags: [free, univ]
+            status: todo
+          - slug: harvard-cs249r
+            title: "Machine Learning Systems (CS249r)"
+            org: "Harvard (Reddi)"
+            code: "CS249r"
+            tags: [free, univ]
+            status: todo
+          - slug: stanford-stanford-mlsys-seminar-series
+            title: "Stanford MLSys Seminar Series"
+            org: "Stanford"
+            tags: [free, series]
+            status: todo
+      - name: "Distributed systems substrate"
+        courses:
+          - slug: mit-6-824
+            title: "Distributed Systems (6.824/6.5840)"
+            org: "MIT"
+            code: "6.824"
+            tags: [free, univ]
+            status: todo
+          - slug: cmu-15-445
+            title: "Database Systems (15-445)"
+            org: "CMU"
+            code: "15-445"
+            tags: [free, univ]
+            status: todo
+  - id: mlops-production-engineeri
+    n: 7
+    name: "MLOps & production engineering"
+    short: "MLOps"
+    tagline: "Shipping, serving, and monitoring models once they leave the notebook."
+    builds_on: [deep-learning-core]
+    domains:
+      - name: "MLOps"
+        courses:
+          - slug: dlai-machine-learning-engineering-for-p
+            title: "Machine Learning Engineering for Production (MLOps) Specialization (4 courses)"
+            org: "DeepLearning.AI"
+            tags: [coursera, paid]
+            status: todo
+          - slug: datatalks-club-mlops-zoomcamp
+            title: "MLOps Zoomcamp"
+            org: "DataTalks.Club"
+            tags: [free, cert]
+            status: todo
+          - slug: fsdl-full-stack-deep-learning
+            title: "Full Stack Deep Learning"
+            org: "FSDL"
+            tags: [free, series]
+            status: todo
+          - slug: made-with-ml-made-with-ml
+            title: "Made With ML"
+            org: "Made With ML"
+            tags: [free, series]
+            status: todo
+      - name: "LLMOps"
+        courses:
+          - slug: dlai-llmops
+            title: "LLMOps"
+            org: "DeepLearning.AI"
+            tags: [free, series]
+            status: todo
+          - slug: fsdl-full-stack-llm-bootcamp
+            title: "Full Stack LLM Bootcamp"
+            org: "FSDL"
+            tags: [free, series]
+            status: todo
+      - name: "Data engineering"
+        courses:
+          - slug: datatalks-club-data-engineering-zoomcamp
+            title: "Data Engineering Zoomcamp"
+            org: "DataTalks.Club"
+            tags: [free, cert]
+            status: todo
+          - slug: ibm-ibm-data-engineering-professional-
+            title: "IBM Data Engineering Professional Certificate"
+            org: "IBM"
+            tags: [coursera, paid, cert]
+            status: todo
+      - name: "Cloud ML certifications"
+        courses:
+          - slug: google-preparing-for-google-cloud-profess
+            title: "Preparing for Google Cloud Professional ML Engineer"
+            org: "Google Cloud"
+            tags: [coursera, paid, cert]
+            status: todo
+          - slug: aws-aws-certified-machine-learning-spe
+            title: "AWS Certified Machine Learning - Specialty"
+            org: "AWS"
+            tags: [paid, cert]
+            status: todo
+          - slug: microsoft-azure-ai-engineer-associate
+            title: "Azure AI Engineer Associate"
+            org: "Microsoft"
+            tags: [paid, cert]
+            status: todo
+  - id: safety-security-privacy-go
+    n: 8
+    name: "Safety, security, privacy & governance"
+    short: "Safety"
+    tagline: "Alignment, adversarial robustness, privacy, and policy. Thin on formal courses, which is itself informative."
+    builds_on: [nlp-transformers-llms]
+    domains:
+      - name: "AI safety & alignment"
+        courses:
+          - slug: bluedot-impact-ai-safety-fundamentals-alignment-c
+            title: "AI Safety Fundamentals - Alignment Course"
+            org: "BlueDot Impact"
+            tags: [free, cert]
+            status: todo
+          - slug: bluedot-impact-ai-safety-fundamentals-governance-
+            title: "AI Safety Fundamentals - Governance Course"
+            org: "BlueDot Impact"
+            tags: [free, cert]
+            status: todo
+          - slug: arena-arena-alignment-research-engineer--2
+            title: "ARENA - Alignment Research Engineer Accelerator"
+            org: "ARENA"
+            tags: [free, series]
+            status: todo
+      - name: "Adversarial ML & LLM security"
+        courses:
+          - slug: dlai-red-teaming-llm-applications
+            title: "Red Teaming LLM Applications"
+            org: "DeepLearning.AI"
+            tags: [free, series]
+            status: todo
+          - slug: dlai-quality-and-safety-for-llm-applica
+            title: "Quality and Safety for LLM Applications"
+            org: "DeepLearning.AI"
+            tags: [free, series]
+            status: todo
+      - name: "Privacy-preserving ML"
+        courses:
+          - slug: openmined-privacy-preserving-ai-series
+            title: "Privacy-Preserving AI series"
+            org: "OpenMined"
+            tags: [free, series]
+            status: todo
+          - slug: openmined-federated-learning-differential-pr
+            title: "Federated Learning / differential privacy modules"
+            org: "OpenMined"
+            tags: [free, series]
+            status: todo
+      - name: "Fairness, ethics & policy"
+        courses:
+          - slug: various-course-ai-ethics-responsible-ai
+            title: "AI Ethics / Responsible AI"
+            org: "various (Coursera catalogue)"
+            tags: [coursera, paid]
+            status: todo
+          - slug: various-provid-eu-ai-act-compliance-training
+            title: "EU AI Act compliance training"
+            org: "various providers"
+            tags: [paid]
+            status: todo
+  - id: research-practice
+    n: 9
+    name: "Research practice"
+    short: "Research"
+    tagline: "Craft rather than knowledge: reading a field, reproducing results, and writing them up."
+    builds_on: [nlp-transformers-llms, ml-systems-efficiency]
+    domains:
+      - name: "Doing and writing research"
+        courses:
+          - slug: ecrire-et-publ-how-to-write-and-publish-a-scienti
+            title: "How to Write and Publish a Scientific Paper"
+            org: "Écrire et publier / Coursera catalogue"
+            tags: [coursera, paid]
+            status: todo
+          - slug: stanford-writing-in-the-sciences
+            title: "Writing in the Sciences"
+            org: "Stanford Online"
+            tags: [free, univ]
+            status: todo

--- a/content/data/ai-roadmap.yml
+++ b/content/data/ai-roadmap.yml
@@ -71,7 +71,7 @@ tiers:
         courses:
           - slug: mitx-6-431x
             title: "Probability - The Science of Uncertainty and Data (6.431x)"
-            org: "MITx / edX"
+            org: "MITx (MIT Open Learning, via MITx Online)"
             code: "6.431x"
             tags: [free, paid, univ]
             status: todo
@@ -117,11 +117,6 @@ tiers:
             org: "Stanford Online"
             code: "EE364B"
             tags: [free, univ]
-            status: todo
-          - slug: melbourne-discrete-optimization
-            title: "Discrete Optimization"
-            org: "University of Melbourne"
-            tags: [coursera, paid]
             status: todo
           - slug: mit-18-335
             title: "Introduction to Numerical Methods (18.335)"
@@ -174,9 +169,9 @@ tiers:
             tags: [free, univ]
             status: todo
           - slug: stanford-cs229t
-            title: "Statistical Learning Theory (CS229T)"
+            title: "Machine Learning Theory (CS229M / STATS214)"
             org: "Stanford"
-            code: "CS229T"
+            code: "CS229M / STATS214"
             tags: [free, univ]
             status: todo
       - name: "Bayesian & probabilistic methods"
@@ -223,8 +218,8 @@ tiers:
       - name: "Causal inference"
         courses:
           - slug: columbia-causal-inference-i-ii
-            title: "Causal Inference I & II"
-            org: "Columbia University"
+            title: "Causal Inference & Causal Inference 2"
+            org: "Columbia University (via Coursera)"
             tags: [coursera, paid]
             status: todo
           - slug: brady-neal-introduction-to-causal-inference
@@ -270,9 +265,9 @@ tiers:
             tags: [free, univ]
             status: todo
           - slug: berkeley-cs182
-            title: "Deep Learning (CS182)"
+            title: "Designing, Visualizing and Understanding Deep Neural Networks (CS182)"
             org: "UC Berkeley"
-            code: "CS182"
+            code: "CS182/282A"
             tags: [free, univ]
             status: todo
           - slug: fastai-practical-deep-learning-for-coders
@@ -425,9 +420,9 @@ tiers:
             tags: [free, cert]
             status: todo
           - slug: berkeley-cs294
-            title: "Large Language Model Agents MOOC"
-            org: "UC Berkeley (Dawn Song)"
-            code: "CS294"
+            title: "Large Language Model Agents (MOOC)"
+            org: "UC Berkeley (Dawn Song, with Xinyun Chen)"
+            code: "CS194/294-196"
             tags: [free, univ]
             status: todo
       - name: "Evaluation & interpretability"
@@ -529,12 +524,6 @@ tiers:
             org: "University of Minnesota"
             tags: [coursera, paid]
             status: todo
-          - slug: stanford-cs276
-            title: "Information Retrieval and Web Search (CS276)"
-            org: "Stanford"
-            code: "CS276"
-            tags: [free, univ]
-            status: todo
           - slug: stanford-cs246
             title: "Mining Massive Datasets (CS246)"
             org: "Stanford"
@@ -579,11 +568,6 @@ tiers:
             org: "NVIDIA DLI"
             tags: [paid, cert]
             status: todo
-          - slug: uiuc-community-programming-massively-parallel-pro
-            title: "Programming Massively Parallel Processors (PMPP) lecture series"
-            org: "UIUC / community"
-            tags: [free, series]
-            status: todo
           - slug: gpu-mode-gpu-mode-lecture-series
             title: "GPU MODE lecture series"
             org: "GPU MODE"
@@ -618,12 +602,6 @@ tiers:
             status: todo
       - name: "ML systems design"
         courses:
-          - slug: stanford-cs329s
-            title: "Machine Learning Systems Design (CS329S)"
-            org: "Stanford"
-            code: "CS329S"
-            tags: [free, univ]
-            status: todo
           - slug: harvard-cs249r
             title: "Machine Learning Systems (CS249r)"
             org: "Harvard (Reddi)"
@@ -644,7 +622,7 @@ tiers:
             tags: [free, univ]
             status: todo
           - slug: cmu-15-445
-            title: "Database Systems (15-445)"
+            title: "Intro to Database Systems (15-445/645)"
             org: "CMU"
             code: "15-445"
             tags: [free, univ]
@@ -675,7 +653,7 @@ tiers:
             status: todo
           - slug: made-with-ml-made-with-ml
             title: "Made With ML"
-            org: "Made With ML"
+            org: "Anyscale (Made With ML)"
             tags: [free, series]
             status: todo
       - name: "LLMOps"
@@ -705,18 +683,13 @@ tiers:
       - name: "Cloud ML certifications"
         courses:
           - slug: google-preparing-for-google-cloud-profess
-            title: "Preparing for Google Cloud Professional ML Engineer"
+            title: "Preparing for Google Cloud Certification: Machine Learning Engineer"
             org: "Google Cloud"
             tags: [coursera, paid, cert]
             status: todo
           - slug: aws-aws-certified-machine-learning-spe
-            title: "AWS Certified Machine Learning - Specialty"
+            title: "AWS Certified Machine Learning Engineer - Associate (MLA-C01)"
             org: "AWS"
-            tags: [paid, cert]
-            status: todo
-          - slug: microsoft-azure-ai-engineer-associate
-            title: "Azure AI Engineer Associate"
-            org: "Microsoft"
             tags: [paid, cert]
             status: todo
   - id: safety-security-privacy-go
@@ -729,12 +702,12 @@ tiers:
       - name: "AI safety & alignment"
         courses:
           - slug: bluedot-impact-ai-safety-fundamentals-alignment-c
-            title: "AI Safety Fundamentals - Alignment Course"
+            title: "AI Alignment"
             org: "BlueDot Impact"
             tags: [free, cert]
             status: todo
           - slug: bluedot-impact-ai-safety-fundamentals-governance-
-            title: "AI Safety Fundamentals - Governance Course"
+            title: "Frontier AI Governance"
             org: "BlueDot Impact"
             tags: [free, cert]
             status: todo
@@ -750,20 +723,10 @@ tiers:
             org: "DeepLearning.AI"
             tags: [free, series]
             status: todo
-          - slug: dlai-quality-and-safety-for-llm-applica
-            title: "Quality and Safety for LLM Applications"
-            org: "DeepLearning.AI"
-            tags: [free, series]
-            status: todo
       - name: "Privacy-preserving ML"
         courses:
           - slug: openmined-privacy-preserving-ai-series
             title: "Privacy-Preserving AI series"
-            org: "OpenMined"
-            tags: [free, series]
-            status: todo
-          - slug: openmined-federated-learning-differential-pr
-            title: "Federated Learning / differential privacy modules"
             org: "OpenMined"
             tags: [free, series]
             status: todo
@@ -790,7 +753,7 @@ tiers:
         courses:
           - slug: ecrire-et-publ-how-to-write-and-publish-a-scienti
             title: "How to Write and Publish a Scientific Paper"
-            org: "Écrire et publier / Coursera catalogue"
+            org: "École Polytechnique"
             tags: [coursera, paid]
             status: todo
           - slug: stanford-writing-in-the-sciences

--- a/src/build/assets.ts
+++ b/src/build/assets.ts
@@ -36,7 +36,7 @@ const STYLE_ORDER = [
 ];
 
 /** Client entrypoints bundled independently; run engines load via dynamic import. */
-const CLIENT_ENTRIES = ["main", "search", "toc", "lightbox", "run"];
+const CLIENT_ENTRIES = ["main", "search", "toc", "lightbox", "run", "roadmap"];
 
 /**
  * The theme-init snippet inlined into <head> before CSS. Its sha256 goes in

--- a/src/build/assets.ts
+++ b/src/build/assets.ts
@@ -25,6 +25,7 @@ const STYLE_ORDER = [
   "components/terminal.css",
   "components/charts.css",
   "components/diagram.css",
+  "components/roadmap.css",
   "prose.css",
   "code.css",
   "pages/home.css",

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -2,6 +2,7 @@
 import { rm, mkdir, cp } from "fs/promises";
 import { join } from "path";
 import { paths, site } from "./config";
+import { load as parseYaml } from "js-yaml";
 import { loadContent, type Article } from "./content";
 import { createRenderer } from "./markdown/pipeline";
 import { buildAssets } from "./assets";
@@ -12,6 +13,7 @@ import { renderHome } from "./render/home";
 import { renderArticlesList } from "./render/articles-list";
 import { renderProjects } from "./render/projects";
 import { renderAbout } from "./render/about";
+import { renderRoadmap, type Roadmap } from "./render/roadmap";
 import { renderNotFound } from "./render/notfound";
 import { collectTags, renderTagPage, renderTagsIndex } from "./render/tags";
 import { writeSearchIndex } from "./search";
@@ -168,6 +170,29 @@ async function main() {
         activeNav: "about",
       },
       renderAbout(),
+      manifest,
+      inlineCss,
+    ),
+  );
+
+  // AI roadmap: a data-driven page, reachable from the footer only.
+  const roadmap = parseYaml(
+    await Bun.file(join(paths.content, "data", "ai-roadmap.yml")).text(),
+  ) as Roadmap;
+  await mkdir(join(paths.dist, "ai"), { recursive: true });
+  await Bun.write(
+    join(paths.dist, "ai", "index.html"),
+    page(
+      {
+        title: roadmap.title,
+        description:
+          "A dependency-ordered map of AI course material: ten tiers from mathematics to research practice, structured courses only.",
+        path: "/ai/",
+        ogImage: DEFAULT_OG,
+        jsonLd: [breadcrumbJsonLd([{ name: roadmap.title, path: "/ai/" }])],
+        bodyClass: "page-roadmap",
+      },
+      renderRoadmap(roadmap),
       manifest,
       inlineCss,
     ),

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -191,6 +191,7 @@ async function main() {
         ogImage: DEFAULT_OG,
         jsonLd: [breadcrumbJsonLd([{ name: roadmap.title, path: "/ai/" }])],
         bodyClass: "page-roadmap",
+        scripts: ["roadmap.js"],
       },
       renderRoadmap(roadmap),
       manifest,

--- a/src/build/render/layout.ts
+++ b/src/build/render/layout.ts
@@ -57,6 +57,9 @@ const NAV_ITEMS = [
   { key: "about", label: "About", href: "/about/" },
 ] as const;
 
+/** Reachable from the footer but deliberately kept out of the main nav. */
+const FOOTER_ONLY_ITEMS = [{ key: "ai", label: "AI roadmap", href: "/ai/" }] as const;
+
 export function page(
   meta: PageMeta,
   body: RawHtml,
@@ -147,7 +150,7 @@ ${body}
 </div>
 <nav class="footer-nav" aria-label="Footer">
 <ul>
-${NAV_ITEMS.map((item) => html`<li><a href="${item.href}">${item.label}</a></li>`)}
+${[...NAV_ITEMS, ...FOOTER_ONLY_ITEMS].map((item) => html`<li><a href="${item.href}">${item.label}</a></li>`)}
 </ul>
 </nav>
 <div class="footer-social">

--- a/src/build/render/roadmap.ts
+++ b/src/build/render/roadmap.ts
@@ -17,7 +17,6 @@ export interface Course {
   title: string;
   org: string;
   code?: string;
-  url?: string;
   tags: string[];
   status?: Status;
   rating?: number;
@@ -67,13 +66,10 @@ function tally(done: number, total: number): RawHtml {
   return html`<span class="rm-tally">${String(done)} of ${String(total)} done</span>`;
 }
 
-function courseItem(c: Course): RawHtml {
+function courseItem(c: Course, showProgress: boolean): RawHtml {
   const status: Status = c.status ?? "todo";
   // data-* attributes are what the (optional) client filter reads
   const haystack = [c.title, c.org, c.code ?? ""].join(" ").toLowerCase();
-  const title = c.url
-    ? html`<a href="${c.url}" target="_blank" rel="noopener">${c.title}</a>`
-    : html`${c.title}`;
 
   const verdict = c.verdict
     ? html`<details class="rm-verdict">
@@ -87,22 +83,27 @@ function courseItem(c: Course): RawHtml {
       ? html`<span class="rm-rating"><span class="sr-only">Rated </span>${String(c.rating)}<span aria-hidden="true">/5</span></span>`
       : null;
 
+  // With nothing completed yet, "not started" on all 118 entries is noise, not
+  // information; it earns its place once there is real variation to show.
+  const statusLabel = showProgress
+    ? html`<span class="rm-status rm-status--${status}">${STATUS_LABEL[status]}</span>${rating}`
+    : null;
+
   return html`<li class="rm-course" data-status="${status}" data-tags="${c.tags.join(",")}" data-find="${haystack}">
 <span class="rm-course__marker rm-course__marker--${status}" aria-hidden="true"></span>
 <div class="rm-course__body">
-<span class="rm-course__title">${title}</span>
+<span class="rm-course__title">${c.title}</span>
 <span class="rm-course__meta">
 <span class="rm-org">${c.org}</span>${c.code ? html`<span class="rm-code">${c.code}</span>` : null}
 ${c.tags.map((t) => html`<span class="rm-tag rm-tag--${t}">${t}</span>`)}
-<span class="rm-status rm-status--${status}">${STATUS_LABEL[status]}</span>
-${rating}
+${statusLabel}
 </span>
 ${verdict}
 </div>
 </li>`;
 }
 
-function tierSection(t: Tier, all: Tier[]): RawHtml {
+function tierSection(t: Tier, all: Tier[], showProgress: boolean): RawHtml {
   const list = courses(t);
   const done = doneCount(list);
   const deps = (t.builds_on ?? [])
@@ -117,14 +118,14 @@ function tierSection(t: Tier, all: Tier[]): RawHtml {
 ${deps.length
     ? html`<span class="rm-builds">Builds on ${deps.join(" and ")}</span>`
     : html`<span class="rm-builds rm-builds--none">No prerequisites</span>`}
-${tally(done, list.length)}${bar(done, list.length)}
+${showProgress ? html`${tally(done, list.length)}${bar(done, list.length)}` : null}
 </p>
 </header>
 ${t.domains.map(
     (d) => html`<section class="rm-domain">
 <h3 class="rm-domain__title">${d.name}</h3>
 <ul class="rm-courses">
-${d.courses.map(courseItem)}
+${d.courses.map((c) => courseItem(c, showProgress))}
 </ul>
 </section>`,
   )}
@@ -134,12 +135,16 @@ ${d.courses.map(courseItem)}
 export function renderRoadmap(data: Roadmap): RawHtml {
   const all = data.tiers.flatMap(courses);
   const done = doneCount(all);
+  // The progress chrome (bars, tallies, per-course status) earns its place once
+  // there is real status to show; at all-todo it would just repeat "0%"/"not
+  // started" 118 times. It reappears on its own the day a course changes status.
+  const showProgress = all.some((c) => (c.status ?? "todo") !== "todo");
 
   return html`<article class="rm">
 <header class="rm-head">
 <h1>${data.title}</h1>
 <p class="rm-lede">${data.lede}</p>
-<p class="rm-overall">${tally(done, all.length)}${bar(done, all.length)}</p>
+${showProgress ? html`<p class="rm-overall">${tally(done, all.length)}${bar(done, all.length)}</p>` : null}
 </header>
 
 ${raw(renderSpine(data.tiers))}
@@ -169,6 +174,6 @@ ${TAGS.map(
 <p class="rm-controls__count" id="rm-count" role="status"></p>
 </div>
 
-${data.tiers.map((t) => tierSection(t, data.tiers))}
+${data.tiers.map((t) => tierSection(t, data.tiers, showProgress))}
 </article>`;
 }

--- a/src/build/render/roadmap.ts
+++ b/src/build/render/roadmap.ts
@@ -1,0 +1,174 @@
+import { marked } from "marked";
+import { html, raw, type RawHtml } from "./html";
+import { renderSpine, type SpineTier } from "../roadmap/spine";
+
+/**
+ * The AI roadmap page: a dependency-ordered map of AI course material.
+ *
+ * Everything here renders at build time. Progress counts come from the `status`
+ * field in content/data/ai-roadmap.yml, so the page needs no client state, and
+ * the search/filter controls ship hidden until the client script reveals them.
+ */
+
+export type Status = "todo" | "doing" | "done";
+
+export interface Course {
+  slug: string;
+  title: string;
+  org: string;
+  code?: string;
+  url?: string;
+  tags: string[];
+  status?: Status;
+  rating?: number;
+  verdict?: string;
+}
+
+export interface Domain {
+  name: string;
+  courses: Course[];
+}
+
+export interface Tier extends SpineTier {
+  tagline: string;
+  domains: Domain[];
+}
+
+export interface Roadmap {
+  title: string;
+  lede: string;
+  note: string;
+  tiers: Tier[];
+}
+
+export const TAGS = ["free", "paid", "coursera", "univ", "cert", "series"] as const;
+
+const STATUS_LABEL: Record<Status, string> = {
+  done: "done",
+  doing: "in progress",
+  todo: "not started",
+};
+
+function courses(tier: Tier): Course[] {
+  return tier.domains.flatMap((d) => d.courses);
+}
+
+function doneCount(list: Course[]): number {
+  return list.filter((c) => c.status === "done").length;
+}
+
+/** A decorative bar; the count beside it carries the meaning for screen readers. */
+function bar(done: number, total: number): RawHtml {
+  const pct = total ? Math.round((done / total) * 1000) / 10 : 0;
+  return html`<span class="rm-bar" aria-hidden="true"><i style="width:${String(pct)}%"></i></span>`;
+}
+
+function tally(done: number, total: number): RawHtml {
+  return html`<span class="rm-tally">${String(done)} of ${String(total)} done</span>`;
+}
+
+function courseItem(c: Course): RawHtml {
+  const status: Status = c.status ?? "todo";
+  // data-* attributes are what the (optional) client filter reads
+  const haystack = [c.title, c.org, c.code ?? ""].join(" ").toLowerCase();
+  const title = c.url
+    ? html`<a href="${c.url}" target="_blank" rel="noopener">${c.title}</a>`
+    : html`${c.title}`;
+
+  const verdict = c.verdict
+    ? html`<details class="rm-verdict">
+<summary>Notes</summary>
+<div class="rm-verdict__body">${raw(marked.parseInline(c.verdict) as string)}</div>
+</details>`
+    : null;
+
+  const rating =
+    status === "done" && c.rating
+      ? html`<span class="rm-rating"><span class="sr-only">Rated </span>${String(c.rating)}<span aria-hidden="true">/5</span></span>`
+      : null;
+
+  return html`<li class="rm-course" data-status="${status}" data-tags="${c.tags.join(",")}" data-find="${haystack}">
+<span class="rm-course__marker rm-course__marker--${status}" aria-hidden="true"></span>
+<div class="rm-course__body">
+<span class="rm-course__title">${title}</span>
+<span class="rm-course__meta">
+<span class="rm-org">${c.org}</span>${c.code ? html`<span class="rm-code">${c.code}</span>` : null}
+${c.tags.map((t) => html`<span class="rm-tag rm-tag--${t}">${t}</span>`)}
+<span class="rm-status rm-status--${status}">${STATUS_LABEL[status]}</span>
+${rating}
+</span>
+${verdict}
+</div>
+</li>`;
+}
+
+function tierSection(t: Tier, all: Tier[]): RawHtml {
+  const list = courses(t);
+  const done = doneCount(list);
+  const deps = (t.builds_on ?? [])
+    .map((id) => all.find((x) => x.id === id)?.name)
+    .filter((n): n is string => Boolean(n));
+
+  return html`<section class="rm-tier" id="${t.id}" style="--tier:var(--tier-${String(t.n)})">
+<header class="rm-tier__head">
+<h2 class="rm-tier__title"><span class="rm-tier__num" aria-hidden="true">${String(t.n)}</span><span class="sr-only">Tier ${String(t.n)}. </span>${t.name}</h2>
+<p class="rm-tier__tagline">${t.tagline}</p>
+<p class="rm-tier__meta">
+${deps.length
+    ? html`<span class="rm-builds">Builds on ${deps.join(" and ")}</span>`
+    : html`<span class="rm-builds rm-builds--none">No prerequisites</span>`}
+${tally(done, list.length)}${bar(done, list.length)}
+</p>
+</header>
+${t.domains.map(
+    (d) => html`<section class="rm-domain">
+<h3 class="rm-domain__title">${d.name}</h3>
+<ul class="rm-courses">
+${d.courses.map(courseItem)}
+</ul>
+</section>`,
+  )}
+</section>`;
+}
+
+export function renderRoadmap(data: Roadmap): RawHtml {
+  const all = data.tiers.flatMap(courses);
+  const done = doneCount(all);
+
+  return html`<article class="rm">
+<header class="rm-head">
+<h1>${data.title}</h1>
+<p class="rm-lede">${data.lede}</p>
+<p class="rm-overall">${tally(done, all.length)}${bar(done, all.length)}</p>
+</header>
+
+${raw(renderSpine(data.tiers))}
+
+<nav class="rm-jump" aria-label="Tiers">
+<ul>
+${data.tiers.map(
+    (t) => html`<li style="--tier:var(--tier-${String(t.n)})"><a href="#${t.id}"><span class="rm-jump__num" aria-hidden="true">${String(t.n)}</span>${t.short}</a></li>`,
+  )}
+</ul>
+</nav>
+
+<p class="rm-note">${data.note}</p>
+
+<div class="rm-controls" id="rm-controls" hidden>
+<div class="rm-controls__row">
+<label class="rm-search">
+<span class="sr-only">Search courses</span>
+<input type="search" id="rm-q" placeholder="Search course, code or institution" autocomplete="off">
+</label>
+</div>
+<div class="rm-controls__row" role="group" aria-label="Filter by kind">
+${TAGS.map(
+    (t) => html`<button type="button" class="rm-fil" data-f="${t}" aria-pressed="false">${t}</button>`,
+  )}
+</div>
+<p class="rm-controls__count" id="rm-count" role="status"></p>
+</div>
+
+${data.tiers.map((t) => tierSection(t, data.tiers))}
+</article>`;
+}

--- a/src/build/roadmap/spine.ts
+++ b/src/build/roadmap/spine.ts
@@ -1,0 +1,139 @@
+import { escapeAttr, escapeHtml } from "../render/html";
+
+/**
+ * The roadmap's overview graphic: the tier dependency graph drawn as a trunk
+ * that fans into branches.
+ *
+ * The tier graph is a DAG, not a tree (tier 9 builds on two tiers at once), so
+ * rows come from a longest-path pass rather than a parent pointer. That keeps
+ * the drawing correct if the `builds_on` edges in the data change.
+ *
+ * Conventions follow src/build/markdown/diagram.ts: the SVG is decorative
+ * (role="img" plus a text summary), colours arrive as CSS custom properties so
+ * both themes work, and marker ids are suffixed to stay unique on the page.
+ * Tier colours are never used for text, only for geometry, because several of
+ * them do not reach 4.5:1 against the light background.
+ */
+
+export interface SpineTier {
+  id: string;
+  n: number;
+  short: string;
+  name: string;
+  builds_on?: string[];
+}
+
+const NODE_H = 34;
+const CHAR_W = 7.3; // avg glyph advance for the UI font at 14px, as in diagram.ts
+const PAD_X = 14;
+const ROW_GAP = 78;
+const COL_GAP = 14;
+const MARGIN = 10;
+
+function nodeWidth(label: string): number {
+  return Math.max(label.length * CHAR_W + PAD_X * 2, 62);
+}
+
+/** Longest path from any root, so a node always sits below every parent. */
+function rowOf(tiers: SpineTier[]): Map<string, number> {
+  const byId = new Map(tiers.map((t) => [t.id, t]));
+  const memo = new Map<string, number>();
+  const walk = (id: string, seen: Set<string>): number => {
+    if (memo.has(id)) return memo.get(id)!;
+    const t = byId.get(id);
+    const parents = (t?.builds_on ?? []).filter((p) => byId.has(p) && !seen.has(p));
+    const depth = parents.length
+      ? Math.max(...parents.map((p) => walk(p, new Set([...seen, id])) + 1))
+      : 0;
+    memo.set(id, depth);
+    return depth;
+  };
+  for (const t of tiers) walk(t.id, new Set());
+  return memo;
+}
+
+export function renderSpine(tiers: SpineTier[]): string {
+  if (!tiers.length) return "";
+
+  const rows = rowOf(tiers);
+  const byRow = new Map<number, SpineTier[]>();
+  for (const t of tiers) {
+    const r = rows.get(t.id) ?? 0;
+    if (!byRow.has(r)) byRow.set(r, []);
+    byRow.get(r)!.push(t);
+  }
+  for (const list of byRow.values()) list.sort((a, b) => a.n - b.n);
+
+  // widest row sets the drawing width; every row is centred within it
+  let width = 0;
+  for (const list of byRow.values()) {
+    const w = list.reduce((sum, t) => sum + nodeWidth(t.short), 0) + COL_GAP * (list.length - 1);
+    width = Math.max(width, w);
+  }
+
+  const pos = new Map<string, { x: number; y: number; w: number }>();
+  for (const [r, list] of byRow) {
+    const rowW = list.reduce((s, t) => s + nodeWidth(t.short), 0) + COL_GAP * (list.length - 1);
+    let x = (width - rowW) / 2;
+    for (const t of list) {
+      const w = nodeWidth(t.short);
+      pos.set(t.id, { x, y: r * ROW_GAP, w });
+      x += w + COL_GAP;
+    }
+  }
+
+  const maxRow = Math.max(...byRow.keys());
+  const height = maxRow * ROW_GAP + NODE_H;
+
+  // edges first so nodes paint over them
+  const edges: string[] = [];
+  for (const t of tiers) {
+    for (const parentId of t.builds_on ?? []) {
+      const p = pos.get(parentId);
+      const c = pos.get(t.id);
+      if (!p || !c) continue;
+      const x1 = p.x + p.w / 2;
+      const y1 = p.y + NODE_H;
+      const x2 = c.x + c.w / 2;
+      const y2 = c.y;
+      const mid = (y1 + y2) / 2;
+      edges.push(
+        `<path class="spine__edge" d="M ${x1.toFixed(1)} ${y1.toFixed(1)} C ${x1.toFixed(1)} ${mid.toFixed(1)}, ${x2.toFixed(1)} ${mid.toFixed(1)}, ${x2.toFixed(1)} ${y2.toFixed(1)}"/>`,
+      );
+    }
+  }
+
+  const nodes = tiers.map((t) => {
+    const p = pos.get(t.id)!;
+    const cx = p.x + p.w / 2;
+    return (
+      `<g class="spine__node" style="--tier:var(--tier-${t.n})">` +
+      `<rect x="${p.x.toFixed(1)}" y="${p.y.toFixed(1)}" width="${p.w.toFixed(1)}" height="${NODE_H}" rx="${(NODE_H / 2).toFixed(1)}"/>` +
+      `<text class="spine__label" x="${cx.toFixed(1)}" y="${(p.y + NODE_H / 2).toFixed(1)}" text-anchor="middle" dominant-baseline="central">${escapeHtml(t.short)}</text>` +
+      `</g>`
+    );
+  });
+
+  const summary =
+    `Tier dependency graph. ` +
+    tiers
+      .map((t) => {
+        const deps = (t.builds_on ?? [])
+          .map((id) => tiers.find((x) => x.id === id)?.name)
+          .filter(Boolean);
+        return deps.length
+          ? `${t.name} builds on ${deps.join(" and ")}`
+          : `${t.name} has no prerequisites`;
+      })
+      .join(". ") + ".";
+
+  const vb = `${-MARGIN} ${-MARGIN} ${(width + MARGIN * 2).toFixed(1)} ${(height + MARGIN * 2).toFixed(1)}`;
+  return (
+    `<figure class="spine">` +
+    `<svg class="spine__svg" viewBox="${vb}" role="img" aria-label="${escapeAttr(summary)}" preserveAspectRatio="xMidYMid meet">` +
+    edges.join("") +
+    nodes.join("") +
+    `</svg>` +
+    `</figure>`
+  );
+}

--- a/src/client/roadmap.ts
+++ b/src/client/roadmap.ts
@@ -1,0 +1,52 @@
+/** AI roadmap search + filter. The controls render `hidden` in markup and are
+ *  revealed here, so nothing dead appears on a page with JS disabled. */
+
+const controls = document.getElementById("rm-controls");
+if (controls) {
+  controls.hidden = false;
+
+  const input = document.getElementById("rm-q") as HTMLInputElement | null;
+  const count = document.getElementById("rm-count");
+  const filters = [...document.querySelectorAll<HTMLButtonElement>(".rm-fil")];
+  const courses = [...document.querySelectorAll<HTMLLIElement>(".rm-course")];
+  const domains = [...document.querySelectorAll<HTMLElement>(".rm-domain")];
+
+  let activeTag: string | null = null;
+  let query = "";
+
+  function apply(): void {
+    let visible = 0;
+    for (const c of courses) {
+      const tags = (c.dataset.tags ?? "").split(",");
+      const okTag = !activeTag || tags.includes(activeTag);
+      const okQuery = !query || (c.dataset.find ?? "").includes(query);
+      const show = okTag && okQuery;
+      c.hidden = !show;
+      if (show) visible++;
+    }
+    for (const d of domains) {
+      d.hidden = d.querySelectorAll(".rm-course:not([hidden])").length === 0;
+    }
+    if (count) {
+      count.textContent = activeTag || query ? `${String(visible)} of ${String(courses.length)} shown` : "";
+    }
+  }
+
+  if (input) {
+    input.addEventListener("input", () => {
+      query = input.value.trim().toLowerCase();
+      apply();
+    });
+  }
+
+  for (const btn of filters) {
+    btn.addEventListener("click", () => {
+      const tag = btn.dataset.f ?? null;
+      const turningOn = btn.getAttribute("aria-pressed") !== "true";
+      for (const b of filters) b.setAttribute("aria-pressed", "false");
+      if (turningOn) btn.setAttribute("aria-pressed", "true");
+      activeTag = turningOn ? tag : null;
+      apply();
+    });
+  }
+}

--- a/src/styles/components/roadmap.css
+++ b/src/styles/components/roadmap.css
@@ -1,0 +1,508 @@
+/* AI roadmap page (/ai/).
+   Tier colours are used for geometry and accents only, never for text: several
+   of them do not reach 4.5:1 against the light background, and the a11y gate is
+   a perfect score. Text always uses the standard tokens. */
+
+:root {
+  --tier-0: #5566a8;
+  --tier-1: #3f74ac;
+  --tier-2: #2c86ad;
+  --tier-3: #1d8f9b;
+  --tier-4: #2a9479;
+  --tier-5: #579a55;
+  --tier-6: #7f8c33;
+  --tier-7: #9c7f28;
+  --tier-8: #a4652b;
+  --tier-9: #a8523f;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --tier-0: #93a2e0;
+    --tier-1: #79aae4;
+    --tier-2: #5cc0e2;
+    --tier-3: #43cbd6;
+    --tier-4: #4fd0aa;
+    --tier-5: #83d181;
+    --tier-6: #bdcc5e;
+    --tier-7: #e0bd52;
+    --tier-8: #eda05f;
+    --tier-9: #e8806c;
+  }
+}
+
+:root[data-theme="dark"] {
+  --tier-0: #93a2e0;
+  --tier-1: #79aae4;
+  --tier-2: #5cc0e2;
+  --tier-3: #43cbd6;
+  --tier-4: #4fd0aa;
+  --tier-5: #83d181;
+  --tier-6: #bdcc5e;
+  --tier-7: #e0bd52;
+  --tier-8: #eda05f;
+  --tier-9: #e8806c;
+}
+
+:root[data-theme="light"] {
+  --tier-0: #5566a8;
+  --tier-1: #3f74ac;
+  --tier-2: #2c86ad;
+  --tier-3: #1d8f9b;
+  --tier-4: #2a9479;
+  --tier-5: #579a55;
+  --tier-6: #7f8c33;
+  --tier-7: #9c7f28;
+  --tier-8: #a4652b;
+  --tier-9: #a8523f;
+}
+
+.rm {
+  max-width: 62rem;
+  margin-inline: auto;
+}
+
+.rm-head h1 {
+  font-size: clamp(1.9rem, 4vw, 2.6rem);
+  line-height: 1.12;
+  letter-spacing: -0.02em;
+  margin: 0 0 var(--space-sm);
+  text-wrap: balance;
+}
+
+.rm-lede {
+  color: var(--color-text-secondary);
+  max-width: 62ch;
+  margin: 0 0 var(--space-md);
+}
+
+/* --- progress --- */
+
+.rm-overall,
+.rm-tier__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-xs) var(--space-sm);
+  margin: 0;
+}
+
+.rm-tally {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.rm-bar {
+  flex: 1 1 8rem;
+  min-width: 5rem;
+  max-width: 22rem;
+  height: 5px;
+  border-radius: var(--radius-full);
+  background: var(--color-border);
+  overflow: hidden;
+}
+
+.rm-bar > i {
+  display: block;
+  height: 100%;
+  background: var(--tier, var(--color-accent));
+}
+
+/* --- the spine graphic --- */
+
+.spine {
+  margin: var(--space-lg) 0 var(--space-xl);
+  overflow-x: auto;
+}
+
+.spine__svg {
+  display: block;
+  /* Cap near the natural viewBox width: letting it stretch to the container
+     scales the label text up with it and the graphic stops looking considered. */
+  width: 100%;
+  max-width: 36rem;
+  min-width: 30rem;
+  height: auto;
+  margin-inline: auto;
+}
+
+.spine__edge {
+  fill: none;
+  stroke: var(--color-border-strong);
+  stroke-width: 1.5;
+}
+
+.spine__node > rect {
+  fill: color-mix(in oklab, var(--tier) 14%, var(--color-surface));
+  stroke: var(--tier);
+  stroke-width: 1.5;
+}
+
+.spine__label {
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 600;
+  fill: var(--color-text);
+}
+
+/* --- tier jump nav --- */
+
+.rm-jump ul {
+  list-style: none;
+  margin: 0 0 var(--space-lg);
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2xs);
+}
+
+.rm-jump a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  padding: 0.3em 0.7em;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  transition: border-color var(--dur-1) var(--ease), color var(--dur-1) var(--ease);
+}
+
+.rm-jump a:hover {
+  border-color: var(--tier);
+  color: var(--color-text);
+}
+
+.rm-jump__num,
+.rm-tier__num {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  color: #fff;
+  background: var(--tier);
+  border-radius: var(--radius-sm);
+  display: inline-grid;
+  place-items: center;
+}
+
+.rm-jump__num {
+  width: 1.15rem;
+  height: 1.15rem;
+  font-size: 0.62rem;
+}
+
+.rm-note {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  max-width: 68ch;
+  padding-top: var(--space-md);
+  border-top: 1px solid var(--color-border);
+  margin: 0 0 var(--space-lg);
+}
+
+/* --- search + filters (revealed by the client script) --- */
+
+.rm-controls {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  margin: 0 0 var(--space-xl);
+}
+
+.rm-controls[hidden] {
+  display: none;
+}
+
+.rm-controls__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2xs);
+}
+
+.rm-search {
+  flex: 1 1 16rem;
+}
+
+.rm-search input {
+  width: 100%;
+  padding: 0.45em 0.7em;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font: inherit;
+  font-size: var(--text-sm);
+}
+
+.rm-fil {
+  font: inherit;
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  padding: 0.28em 0.75em;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+
+.rm-fil[aria-pressed="true"] {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: #fff;
+}
+
+.rm-controls__count {
+  margin: 0;
+  min-height: 1.2em;
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+/* --- tiers --- */
+
+.rm-tier {
+  border-top: 1px solid var(--color-border);
+  padding-top: var(--space-lg);
+  margin-bottom: var(--space-2xl);
+  scroll-margin-top: calc(var(--header-height) + 1rem);
+}
+
+.rm-tier__title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  font-size: var(--text-xl);
+  letter-spacing: -0.011em;
+  margin: 0 0 var(--space-2xs);
+}
+
+.rm-tier__num {
+  width: 1.7rem;
+  height: 1.7rem;
+  font-size: var(--text-sm);
+  flex: none;
+}
+
+.rm-tier__tagline {
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+  max-width: 68ch;
+  margin: 0 0 var(--space-xs);
+}
+
+.rm-builds {
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  padding: 0.15em 0.6em;
+  border-radius: var(--radius-full);
+  border: 1px solid color-mix(in oklab, var(--tier) 35%, transparent);
+  background: color-mix(in oklab, var(--tier) 8%, transparent);
+}
+
+.rm-builds--none {
+  border-style: dashed;
+  background: none;
+}
+
+/* --- domains: the branch lines are drawn with a border, not markup --- */
+
+.rm-domain {
+  margin-top: var(--space-md);
+  padding-left: var(--space-md);
+  border-left: 2px solid color-mix(in oklab, var(--tier) 30%, transparent);
+}
+
+.rm-domain__title {
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+  margin: 0 0 var(--space-xs);
+}
+
+.rm-courses {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-2xs);
+}
+
+.rm-course {
+  display: grid;
+  grid-template-columns: 0.85rem 1fr;
+  gap: var(--space-xs);
+  align-items: start;
+}
+
+.rm-course[hidden] {
+  display: none;
+}
+
+.rm-course__marker {
+  width: 0.55rem;
+  height: 0.55rem;
+  margin-top: 0.42em;
+  border-radius: var(--radius-full);
+  border: 1.5px solid var(--tier);
+}
+
+.rm-course__marker--done {
+  background: var(--tier);
+}
+
+.rm-course__marker--doing {
+  background: linear-gradient(to right, var(--tier) 50%, transparent 50%);
+}
+
+.rm-course__title {
+  display: block;
+  font-size: var(--text-sm);
+  line-height: 1.4;
+  color: var(--color-text);
+}
+
+.rm-course__title a {
+  color: var(--color-text);
+  text-decoration: underline;
+  text-decoration-color: color-mix(in oklab, var(--tier) 55%, transparent);
+  text-underline-offset: 2.5px;
+}
+
+.rm-course__title a:hover {
+  color: var(--color-accent-strong);
+}
+
+.rm-course__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.2em 0.5em;
+  margin-top: 0.1em;
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+.rm-code {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  padding: 0.05em 0.35em;
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-subtle);
+  color: var(--color-text-secondary);
+}
+
+.rm-tag {
+  font-size: 0.6rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-weight: 700;
+  padding: 0.1em 0.4em;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-secondary);
+}
+
+.rm-tag--free { color: var(--color-success); border-color: color-mix(in oklab, var(--color-success) 40%, transparent); }
+.rm-tag--paid { color: var(--color-warning); border-color: color-mix(in oklab, var(--color-warning) 40%, transparent); }
+.rm-tag--univ,
+.rm-tag--coursera { color: var(--color-info); border-color: color-mix(in oklab, var(--color-info) 40%, transparent); }
+
+/* status is spelled out; never colour alone */
+.rm-status {
+  font-size: 0.6rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.rm-status--todo {
+  /* the default state is the quiet one: keep it out of the way */
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.rm-status--done { color: var(--color-success); }
+.rm-status--doing { color: var(--color-info); }
+
+.rm-rating {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--color-text-secondary);
+}
+
+.rm-verdict {
+  margin-top: 0.3em;
+}
+
+.rm-verdict > summary {
+  cursor: pointer;
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  color: var(--color-accent);
+  width: fit-content;
+}
+
+.rm-verdict__body {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  border-left: 2px solid var(--color-border);
+  padding-left: var(--space-sm);
+  margin-top: 0.35em;
+  max-width: 62ch;
+}
+
+/* --- scroll reveal ---
+   Layered so the default state is fully visible: unsupported browsers, print,
+   reduced-motion users and the Lighthouse crawler all see complete content.
+   Deleting this block leaves a correct static page. */
+
+@media (prefers-reduced-motion: no-preference) {
+  @supports (animation-timeline: view()) {
+    .rm-tier,
+    .spine {
+      animation: rm-reveal linear both;
+      animation-timeline: view();
+      animation-range: entry 5% entry 55%;
+    }
+
+    .spine__node {
+      animation: rm-pop linear both;
+      animation-timeline: view();
+      animation-range: entry 10% entry 70%;
+    }
+  }
+}
+
+@keyframes rm-reveal {
+  from { opacity: 0; transform: translateY(14px); }
+  to { opacity: 1; transform: none; }
+}
+
+@keyframes rm-pop {
+  from { opacity: 0.25; }
+  to { opacity: 1; }
+}
+
+@media print {
+  .rm-controls,
+  .rm-jump { display: none; }
+  .rm-tier { break-inside: avoid; }
+}
+
+@media (max-width: 640px) {
+  .rm-domain { padding-left: var(--space-sm); }
+  .rm-tier__title { font-size: var(--text-lg); }
+}

--- a/src/styles/components/roadmap.css
+++ b/src/styles/components/roadmap.css
@@ -369,17 +369,6 @@
   color: var(--color-text);
 }
 
-.rm-course__title a {
-  color: var(--color-text);
-  text-decoration: underline;
-  text-decoration-color: color-mix(in oklab, var(--tier) 55%, transparent);
-  text-underline-offset: 2.5px;
-}
-
-.rm-course__title a:hover {
-  color: var(--color-accent-strong);
-}
-
 .rm-course__meta {
   display: flex;
   flex-wrap: wrap;
@@ -424,16 +413,11 @@
   font-weight: 700;
 }
 
-.rm-status--todo {
-  /* the default state is the quiet one: keep it out of the way */
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  clip-path: inset(50%);
-  white-space: nowrap;
-}
-
+/* The status label only renders once at least one course has moved off
+   "todo" (see showProgress in roadmap.ts), so by the time "not started"
+   appears here it is meaningful contrast against a tier's other courses,
+   not noise, and stays visible like the other two states. */
+.rm-status--todo { color: var(--color-text-muted); }
 .rm-status--done { color: var(--color-success); }
 .rm-status--doing { color: var(--color-info); }
 


### PR DESCRIPTION
A dependency-ordered map of AI course material, extracted and de-personalised from a private study plan, then fact-checked. Reachable from the footer only, not the main nav.

## What's here (3 commits, all landed)

**The page.** 10 tiers, 39 domains, **111 courses** (118 originally, 7 removed on verification — see below). Everything renders at build time; no runtime dependency was added. The tier graph is a **DAG, not a tree** (the last tier builds on two others at once); `src/build/roadmap/spine.ts` lays it out with a longest-path pass, following the SVG conventions already used by `src/build/markdown/diagram.ts`. Scroll reveal is CSS-only, doubly guarded (`prefers-reduced-motion: no-preference` + `@supports (animation-timeline: view())`), so unsupported browsers, reduced-motion, print, and no-JS all see the complete page immediately.

**De-personalisation.** 7 of 10 tier taglines were written for Albert specifically ("You have most of it from FIB", "CS336 is the single highest-value item... for you") — rewritten for a general reader. One course was dropped outright: a UPC doctoral-complement module nobody else could enrol in.

**No links, permanently.** Not deferred to a later phase — decided against outright. 100+ of the 118 entries never had a real link anyway, and maintaining 100+ external URLs against inevitable link rot wasn't worth it. Every course resolves by title + institution + code instead. Removed the `Course.url` field, the conditional anchor rendering, and the dead CSS entirely.

**Verified, not just extracted.** Fanned 6 web-search agents across the tiers to check all 118 courses actually exist, are correctly titled/coded/attributed, and haven't been renamed, merged, or discontinued — then adversarially rechecked every flag before touching anything (a single agent's "this is wrong" isn't enough to alter or remove public content). 96 of 118 were fine as-is.
- **12 corrected**: renames (Stanford CS229T → *Machine Learning Theory*), rebrands (BlueDot Impact's courses, Made With ML → Anyscale), a garbled org name ("Écrire et publier" was a mistranslated title fragment, not an org — it's École Polytechnique's), an inaccurate course code, a retiring cert pointed at its named successor.
- **7 removed**: confirmed discontinued with no successor (pulled from Coursera, absent from 3 years of Stanford's own catalog, retirement banners on the providers' own pages), or duplicates that turned out to double-describe an already-listed resource.
- 4 flags were **overturned** on recheck and left untouched — the first pass mistook an anti-bot block or a client-rendered page for evidence of discontinuation.

**Filter and search.** ~490 B gzipped client entry (`src/client/roadmap.ts`), well inside the script budget. The search box and the six kind filters (`free/paid/coursera/univ/cert/series`) render `hidden` in markup and are revealed by the script, so nothing dead appears with JS off. Browser-tested: toggle on/off, text search, and both combined.

**Progress stays invisible until it's real.** Bars, tallies, and per-course status only render once at least one course has moved off `todo` — a plain "does any course have real status" check, not a flag to remember to flip later. Right now every course is `todo`, so the page carries zero progress chrome; it turns itself on the day the first course is marked done.

## Verified
- **28/28 pages** html-validate clean (a11y gate is 1.0)
- Zero personal references in rendered content
- CSS **8.9 KB** gzip / script **491 B** gzip, both comfortably inside budget
- Dark mode, mobile width (no page-level overflow), no-JS state, accessibility tree, keyboard nav all checked in the browser

## Preview
Branch preview deploys via Cloudflare Workers Builds — check the bot comment on this PR, or `/ai/` on the deploy.

## What's left
Nothing code-shaped. Status and short verdicts are content-only, added as courses are actually completed.