### PR TITLE
content(ai-roadmap): structured-course cleanup + alternative/prerequisite relations

### DIFF
--- a/content/data/ai-roadmap.yml
+++ b/content/data/ai-roadmap.yml
@@ -341,6 +341,12 @@ tiers:
             code: "CS336"
             tags: [free, univ]
             status: todo
+          - slug: stanford-cs25
+            title: "Transformers United (CS25)"
+            org: "Stanford"
+            code: "CS25"
+            tags: [free, series]
+            status: todo
           - slug: karpathy-neural-networks-zero-to-hero
             title: "Neural Networks: Zero to Hero"
             org: "Karpathy"
@@ -586,6 +592,11 @@ tiers:
             org: "Harvard (Reddi)"
             code: "CS249r"
             tags: [free, univ]
+            status: todo
+          - slug: stanford-stanford-mlsys-seminar-series
+            title: "Stanford MLSys Seminar Series"
+            org: "Stanford"
+            tags: [free, series]
             status: todo
       - name: "Distributed systems substrate"
         courses:

--- a/content/data/ai-roadmap.yml
+++ b/content/data/ai-roadmap.yml
@@ -4,6 +4,11 @@
 # status: todo | doing | done   (public, shown on the page)
 # rating: 1-5                   (optional, only meaningful once status is done)
 # verdict: markdown            (optional, a couple of sentences)
+# alt_of: <slug>                (optional, points to another course in the same
+#                                domain that this one is a genuine substitute for
+#                                — pick one, not both)
+# builds_on_course: <slug>      (optional, points to a course this one continues
+#                                from as a sequel or real prerequisite)
 ---
 title: The AI knowledge tree
 lede: >-
@@ -38,6 +43,7 @@ tiers:
             code: "18.065"
             tags: [free, univ]
             status: todo
+            builds_on_course: mit-18-06
           - slug: imperial-mathematics-for-machine-learning-l
             title: "Mathematics for Machine Learning: Linear Algebra"
             org: "Imperial College London"
@@ -62,6 +68,7 @@ tiers:
             code: "18.S096"
             tags: [free, univ]
             status: todo
+            builds_on_course: mit-18-02
       - name: "Probability & statistics"
         courses:
           - slug: mitx-6-431x
@@ -70,6 +77,7 @@ tiers:
             code: "6.431x"
             tags: [free, paid, univ]
             status: todo
+            alt_of: harvard-stat-110
           - slug: harvard-stat-110
             title: "Statistics 110: Probability"
             org: "Harvard"
@@ -81,6 +89,7 @@ tiers:
             org: "MITx / edX"
             tags: [paid, cert]
             status: todo
+            builds_on_course: mitx-6-431x
           - slug: ucsc-bayesian-statistics-from-concept-t
             title: "Bayesian Statistics: From Concept to Data Analysis"
             org: "UC Santa Cruz"
@@ -113,6 +122,7 @@ tiers:
             code: "EE364B"
             tags: [free, univ]
             status: todo
+            builds_on_course: stanford-ee364a
           - slug: mit-18-335
             title: "Introduction to Numerical Methods (18.335)"
             org: "MIT OCW"
@@ -198,6 +208,7 @@ tiers:
             org: "Stanford (Koller)"
             tags: [coursera, paid]
             status: todo
+            alt_of: stanford-cs228
           - slug: stanford-cs228
             title: "Probabilistic Graphical Models (CS228)"
             org: "Stanford"
@@ -248,6 +259,7 @@ tiers:
             code: "CS230"
             tags: [free, univ]
             status: todo
+            builds_on_course: dlai-deep-learning-specialization-5-cou
           - slug: cmu-11-785
             title: "Introduction to Deep Learning (11-785)"
             org: "CMU"
@@ -380,6 +392,7 @@ tiers:
             code: "CS336"
             tags: [free, univ]
             status: todo
+            builds_on_course: stanford-cs336
       - name: "Prompting, RAG & context"
         courses:
           - slug: dlai-chatgpt-prompt-engineering-for-dev
@@ -451,6 +464,7 @@ tiers:
             org: "DeepMind × UCL (Silver)"
             tags: [free, series]
             status: todo
+            alt_of: university-of--reinforcement-learning-specializat
       - name: "Deep RL"
         courses:
           - slug: berkeley-cs285
@@ -553,6 +567,7 @@ tiers:
             code: "CS149"
             tags: [free, univ]
             status: todo
+            alt_of: cmu-15-418
           - slug: nvidia-dli-fundamentals-of-accelerated-comput
             title: "Fundamentals of Accelerated Computing with CUDA C/C++"
             org: "NVIDIA DLI"

--- a/content/data/ai-roadmap.yml
+++ b/content/data/ai-roadmap.yml
@@ -43,11 +43,6 @@ tiers:
             org: "Imperial College London"
             tags: [coursera, paid]
             status: todo
-          - slug: 3b1b-essence-of-linear-algebra
-            title: "Essence of Linear Algebra"
-            org: "3Blue1Brown"
-            tags: [free, series]
-            status: todo
       - name: "Calculus & matrix calculus"
         courses:
           - slug: imperial-mathematics-for-machine-learning-m
@@ -346,12 +341,6 @@ tiers:
             code: "CS336"
             tags: [free, univ]
             status: todo
-          - slug: stanford-cs25
-            title: "Transformers United (CS25)"
-            org: "Stanford"
-            code: "CS25"
-            tags: [free, series]
-            status: todo
           - slug: karpathy-neural-networks-zero-to-hero
             title: "Neural Networks: Zero to Hero"
             org: "Karpathy"
@@ -435,11 +424,6 @@ tiers:
           - slug: dlai-automated-testing-for-llmops
             title: "Automated Testing for LLMOps"
             org: "DeepLearning.AI"
-            tags: [free, series]
-            status: todo
-          - slug: arena-arena-alignment-research-engineer-
-            title: "ARENA - Alignment Research Engineer Accelerator curriculum"
-            org: "ARENA"
             tags: [free, series]
             status: todo
   - id: reinforcement-learning
@@ -568,11 +552,6 @@ tiers:
             org: "NVIDIA DLI"
             tags: [paid, cert]
             status: todo
-          - slug: gpu-mode-gpu-mode-lecture-series
-            title: "GPU MODE lecture series"
-            org: "GPU MODE"
-            tags: [free, series]
-            status: todo
       - name: "Deep learning systems & compilers"
         courses:
           - slug: cmu-10-414
@@ -607,11 +586,6 @@ tiers:
             org: "Harvard (Reddi)"
             code: "CS249r"
             tags: [free, univ]
-            status: todo
-          - slug: stanford-stanford-mlsys-seminar-series
-            title: "Stanford MLSys Seminar Series"
-            org: "Stanford"
-            tags: [free, series]
             status: todo
       - name: "Distributed systems substrate"
         courses:

--- a/src/build/render/roadmap.ts
+++ b/src/build/render/roadmap.ts
@@ -21,6 +21,10 @@ export interface Course {
   status?: Status;
   rating?: number;
   verdict?: string;
+  /** Another course in the same domain this one is a genuine substitute for. */
+  alt_of?: string;
+  /** A course (any domain) this one continues from as a sequel or real prerequisite. */
+  builds_on_course?: string;
 }
 
 export interface Domain {
@@ -66,7 +70,7 @@ function tally(done: number, total: number): RawHtml {
   return html`<span class="rm-tally">${String(done)} of ${String(total)} done</span>`;
 }
 
-function courseItem(c: Course, showProgress: boolean): RawHtml {
+function courseItem(c: Course, showProgress: boolean, allCourses: Course[]): RawHtml {
   const status: Status = c.status ?? "todo";
   // data-* attributes are what the (optional) client filter reads
   const haystack = [c.title, c.org, c.code ?? ""].join(" ").toLowerCase();
@@ -89,7 +93,12 @@ function courseItem(c: Course, showProgress: boolean): RawHtml {
     ? html`<span class="rm-status rm-status--${status}">${STATUS_LABEL[status]}</span>${rating}`
     : null;
 
-  return html`<li class="rm-course" data-status="${status}" data-tags="${c.tags.join(",")}" data-find="${haystack}">
+  const prereq = c.builds_on_course ? allCourses.find((x) => x.slug === c.builds_on_course) : undefined;
+  const buildsOn = prereq
+    ? html`<span class="rm-course__builds-on"><span aria-hidden="true">→</span> builds on <a href="#c-${prereq.slug}">${prereq.title}</a></span>`
+    : null;
+
+  return html`<li class="rm-course${prereq ? " rm-course--sequel" : ""}" id="c-${c.slug}" data-status="${status}" data-tags="${c.tags.join(",")}" data-find="${haystack}">
 <span class="rm-course__marker rm-course__marker--${status}" aria-hidden="true"></span>
 <div class="rm-course__body">
 <span class="rm-course__title">${c.title}</span>
@@ -97,13 +106,65 @@ function courseItem(c: Course, showProgress: boolean): RawHtml {
 <span class="rm-org">${c.org}</span>${c.code ? html`<span class="rm-code">${c.code}</span>` : null}
 ${c.tags.map((t) => html`<span class="rm-tag rm-tag--${t}">${t}</span>`)}
 ${statusLabel}
+${buildsOn}
 </span>
 ${verdict}
 </div>
 </li>`;
 }
 
-function tierSection(t: Tier, all: Tier[], showProgress: boolean): RawHtml {
+type DomainItem = { kind: "course"; course: Course } | { kind: "alt-group"; members: Course[] };
+
+/**
+ * Courses linked by `alt_of` render as one clustered "pick one" group instead
+ * of separate list items. `alt_of` may point through more than one hop, so
+ * each course resolves to the root of its chain and courses sharing a root
+ * are grouped together, in the order the root first appears.
+ */
+function domainItems(domain: Domain): DomainItem[] {
+  const bySlug = new Map(domain.courses.map((c) => [c.slug, c]));
+  const rootOf = (slug: string): string => {
+    const seen = new Set<string>();
+    let cur = slug;
+    while (!seen.has(cur)) {
+      seen.add(cur);
+      const parent = bySlug.get(cur)?.alt_of;
+      if (!parent || !bySlug.has(parent)) return cur;
+      cur = parent;
+    }
+    return cur; // cyclic alt_of data — stop rather than loop forever
+  };
+
+  const groups = new Map<string, Course[]>();
+  for (const c of domain.courses) {
+    const root = rootOf(c.slug);
+    if (!groups.has(root)) groups.set(root, []);
+    groups.get(root)!.push(c);
+  }
+
+  const items: DomainItem[] = [];
+  const emitted = new Set<string>();
+  for (const c of domain.courses) {
+    const root = rootOf(c.slug);
+    if (emitted.has(root)) continue;
+    emitted.add(root);
+    const members = groups.get(root)!;
+    items.push(members.length > 1 ? { kind: "alt-group", members } : { kind: "course", course: members[0]! });
+  }
+  return items;
+}
+
+function domainItem(item: DomainItem, showProgress: boolean, allCourses: Course[]): RawHtml {
+  if (item.kind === "course") return courseItem(item.course, showProgress, allCourses);
+  return html`<li class="rm-alt-group">
+<p class="rm-alt-group__label">Pick one</p>
+<ul class="rm-courses rm-courses--nested">
+${item.members.map((c) => courseItem(c, showProgress, allCourses))}
+</ul>
+</li>`;
+}
+
+function tierSection(t: Tier, all: Tier[], allCourses: Course[], showProgress: boolean): RawHtml {
   const list = courses(t);
   const done = doneCount(list);
   const deps = (t.builds_on ?? [])
@@ -125,7 +186,7 @@ ${t.domains.map(
     (d) => html`<section class="rm-domain">
 <h3 class="rm-domain__title">${d.name}</h3>
 <ul class="rm-courses">
-${d.courses.map((c) => courseItem(c, showProgress))}
+${domainItems(d).map((item) => domainItem(item, showProgress, allCourses))}
 </ul>
 </section>`,
   )}
@@ -174,6 +235,6 @@ ${TAGS.map(
 <p class="rm-controls__count" id="rm-count" role="status"></p>
 </div>
 
-${data.tiers.map((t) => tierSection(t, data.tiers, showProgress))}
+${data.tiers.map((t) => tierSection(t, data.tiers, all, showProgress))}
 </article>`;
 }

--- a/src/styles/components/roadmap.css
+++ b/src/styles/components/roadmap.css
@@ -448,6 +448,39 @@
   max-width: 62ch;
 }
 
+/* --- alt_of: courses that are genuine substitutes cluster into one
+   "pick one" group instead of reading as separate, unrelated entries --- */
+
+.rm-alt-group {
+  border: 1px dashed color-mix(in oklab, var(--tier) 35%, transparent);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2xs) var(--space-xs);
+}
+
+.rm-alt-group__label {
+  margin: 0 0 var(--space-2xs);
+  font-family: var(--font-ui);
+  font-size: 0.6rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--color-text-secondary);
+}
+
+.rm-courses--nested {
+  gap: var(--space-2xs);
+}
+
+/* --- builds_on_course: a sequel is nudged in and names what it follows --- */
+
+.rm-course--sequel {
+  padding-left: var(--space-sm);
+}
+
+.rm-course__builds-on {
+  font-style: italic;
+}
+
 /* --- scroll reveal ---
    Layered so the default state is fully visible: unsupported browsers, print,
    reduced-motion users and the Lighthouse crawler all see complete content.


### PR DESCRIPTION
## Summary
- Removes 5 entries from the AI roadmap that aren't structured courses (series/talks with no problem sets), reintroducing exactly two of them (Transformers United / CS25, Stanford MLSys Seminar Series) as deliberate exceptions worth keeping despite not being courses.
- Fixes an unrelated duplicate found during that audit.
- Adds optional `alt_of` and `builds_on_course` fields to course entries so a domain can mark which courses are genuine substitutes ("pick one") versus which build on another as a sequel/prerequisite.
- Populates 10 evidence-backed relations (4 alternative pairs, 6 builds-on pairs) found by researching official course pages/syllabi across all 37 multi-course domains — most courses are left independent on purpose, since sharing a topic isn't the same as sharing scope and rigor.
- Renders alternative pairs as a clustered "Pick one" group and builds-on courses with a small in-page link to the course they continue from.

Net roadmap size: 108 courses across 39 domains, all `status: todo` (progress/verdict chrome stays hidden until real status exists, per prior decision).

## Test plan
- [x] `bun run build` — clean, 108 courses render, no errors
- [x] `bunx html-validate dist/ai/index.html` — clean
- [x] Verified all 4 alt-groups cluster the correct course pairs (DOM check)
- [x] Verified all 6 builds-on annotations resolve to the correct in-page anchor, including the cross-domain CS336 → CS336-2 case
- [x] No duplicate element ids on the page
- [x] Checked computed styles in both light and dark theme
- [x] CSS budget: 8,977 B gzip of 20,480 B (was 7,535 B before this change)